### PR TITLE
Add builds for 4.10+ and osx depexts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ env:
   - PACKAGE="thrift" CAML_VERSION="4.06"
   - PACKAGE="thrift" CAML_VERSION="4.08"
   - PACKAGE="thrift" CAML_VERSION="4.09"
+  - PACKAGE="thrift" CAML_VERSION="4.10"
+  - PACKAGE="thrift" CAML_VERSION="4.11"
+  - PACKAGE="thrift" CAML_VERSION="4.12"

--- a/thrift.opam
+++ b/thrift.opam
@@ -13,6 +13,7 @@ depexts: [
   ["thrift"] {os-family = "arch"}
   ["thrift-compiler"] {os-family = "debian"}
   ["devel/thrift"] {os-family = "bsd"}
+  ["thrift"] {os = "macos" & os-distribution = "homebrew"}
 ]
 dev-repo: "git+https://github.com/vbmithr/ocaml-thrift-lib"
 synopsis: "OCaml bindings for the Apache Thrift RPC system"


### PR DESCRIPTION
Tested locally on OSX 11.5
```
$ opam depext -yt thrift              
# Detecting depexts using vars: arch=x86_64, os=macos, os-distribution=homebrew, os-family=homebrew
# The following system packages are needed:
thrift
# All required OS packages found.
```
